### PR TITLE
Add lapse module

### DIFF
--- a/code/lapse/CMakeLists.txt
+++ b/code/lapse/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(lapse INTERFACE)
+target_include_directories(lapse INTERFACE include)
+
+add_executable(lapse-test examples.cpp)
+target_link_libraries(lapse-test PRIVATE lapse)
+add_test(lapse-test lapse-test)

--- a/code/lapse/examples.cpp
+++ b/code/lapse/examples.cpp
@@ -1,0 +1,47 @@
+//
+// This example shows how to use "lapse" along with std::chrono.
+//
+#include <lapse.h>
+
+#include <iostream>
+
+void millisecond(void)
+{
+  std::chrono::milliseconds elapsed{0};
+
+  unsigned count = (1 << 24);
+
+  lapse::measure(elapsed) << [count] (void)
+  {
+    for (unsigned i = 0; i < count; ++i)
+    {
+      // DO NOTHING
+    }
+  };
+
+  std::cout << count << " iterations take " << elapsed.count() << "ms" << std::endl;
+}
+
+void microsecond(void)
+{
+  std::chrono::microseconds elapsed{0};
+
+  unsigned count = (1 << 24);
+
+  lapse::measure(elapsed) << [count] (void)
+  {
+    for (unsigned i = 0; i < count; ++i)
+    {
+      // DO NOTHING
+    }
+  };
+
+  std::cout << count << " iterations take " << elapsed.count() << "us" << std::endl;
+}
+
+int main(int argc, char **argv)
+{
+  millisecond();
+  microsecond();
+  return 0;
+}

--- a/code/lapse/include/lapse.h
+++ b/code/lapse/include/lapse.h
@@ -1,0 +1,49 @@
+#ifndef __LAPSE_H__
+#define __LAPSE_H__
+
+#include <chrono>
+#include <utility>
+
+namespace lapse
+{
+
+template<class Rep, class Period> class Session
+{
+public:
+  Session(std::chrono::duration<Rep, Period> *out) : _out{out}
+  {
+    // DO NOTHING
+  }
+
+public:
+  template<typename Callable> void measure(Callable cb)
+  {
+    using namespace std::chrono;
+
+    auto beg = steady_clock::now();
+    cb();
+    auto end = steady_clock::now();
+
+    (*_out) += duration_cast<duration<Rep, Period>>(end - beg);
+  }
+
+private:
+  std::chrono::duration<Rep, Period> *_out;
+};
+
+template<class Rep, class Period, typename Callable>
+Session<Rep, Period> &operator<<(Session<Rep, Period> &&sess, Callable &&cb)
+{
+  sess.measure(std::forward<Callable>(cb));
+  return sess;
+}
+
+template<class Rep, class Period>
+Session<Rep, Period> measure(std::chrono::duration<Rep, Period> &out)
+{
+  return Session<Rep, Period>{&out};
+}
+
+} // namespace lapse
+
+#endif // __LAPSE_H__


### PR DESCRIPTION
This commit adds "lapse", a header-only library for elapsed-time
measurement.

Signed-off-by: Jonghyun Park <parjong@gmail.com>