### PR TITLE
Add caffekit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           command: |
             apt install -y git ssh
             apt install -y cmake gcc g++
+            apt install -y libprotobuf-dev protobuf-compiler
 
       - checkout
 

--- a/code/caffekit/CMakeLists.txt
+++ b/code/caffekit/CMakeLists.txt
@@ -1,0 +1,31 @@
+# TODO Support automatic module ON/OFF
+alex_find_package(BVLCCaffeSource EXACT 1.0 REQUIRED)
+# TODO Use alex_find_package later
+find_package(Protobuf MODULE REQUIRED)
+
+file(GLOB_RECURSE SRCS "src/*.cpp")
+
+# TODO Make below as a reusable function
+set(PROTO_SRCDIR "${BVLCCaffeSource_DIR}/src")
+set(PROTO_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+file(MAKE_DIRECTORY ${PROTO_OUTDIR})
+
+unset(GEN_COMMAND)
+list(APPEND GEN_COMMAND "${PROTOBUF_PROTOC_EXECUTABLE}")
+list(APPEND GEN_COMMAND --proto_path="${PROTO_SRCDIR}")
+list(APPEND GEN_COMMAND --cpp_out="${PROTO_OUTDIR}")
+list(APPEND GEN_COMMAND "${PROTO_SRCDIR}/caffe/proto/caffe.proto")
+
+add_custom_command(
+  OUTPUT "${PROTO_OUTDIR}/caffe/proto/caffe.pb.h" "${PROTO_OUTDIR}/caffe/proto/caffe.pb.cc"
+  COMMAND ${GEN_COMMAND}
+  DEPENDS "${PROTO_SRCDIR}/caffe/proto/caffe.proto"
+)
+
+set(Generated_INCLUDE_DIR "${PROTO_OUTDIR}")
+set(Generated_SRCS "${PROTO_OUTDIR}/caffe/proto/caffe.pb.cc")
+
+add_executable(caffekit ${SRCS} ${Generated_SRCS})
+target_include_directories(caffekit PRIVATE ${Generated_INCLUDE_DIR})
+target_include_directories(caffekit PRIVATE ${PROTOBUF_INCLUDE_DIRS})
+target_link_libraries(caffekit PRIVATE ${PROTOBUF_LIBRARIES})

--- a/code/caffekit/src/Main.cpp
+++ b/code/caffekit/src/Main.cpp
@@ -1,0 +1,53 @@
+#include <caffe/proto/caffe.pb.h>
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+
+#include <map>
+#include <string>
+
+#include <iostream>
+
+// TODO Implement "test"
+int decode(int, const char * const *)
+{
+  caffe::NetParameter net;
+
+  // Parse "binary" model from standard input
+  if (!net.ParseFromIstream(&std::cin))
+  {
+    // TODO Show error message
+    return -1;
+  }
+
+  google::protobuf::io::OstreamOutputStream oos{&std::cout};
+
+  if (google::protobuf::TextFormat::Print(net, &oos))
+  {
+    // TODO Show error message
+    return -1;
+  }
+
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  std::map<std::string, int (*)(int, const char * const *)> commands;
+
+  commands["decode"] = decode;
+  // TODO Implement 'encode'
+
+  if (argc < 2)
+  {
+    // TODO Show help message
+    std::cerr << "ERROR: No command found" << std::endl;
+    return -1;
+  }
+
+  std::string command{argv[1]};
+
+  // TODO Check whether 'command' is valid or not
+  auto func = commands.at(command);
+  return func(0, nullptr);;
+}


### PR DESCRIPTION
This commit adds 'caffeket' module, a command-line toolkit for caffe
(text/binary) model files.

NOTE The current version supports only 'decode' command.

Signed-off-by: Jonghyun Park <parjong@gmail.com>