### PR TITLE
Add "pepper-strcast"

### DIFF
--- a/code/pepper-strcast/CMakeLists.txt
+++ b/code/pepper-strcast/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(pepper-strcast src/strcast.cpp)
+target_include_directories(pepper-strcast PUBLIC include)
+
+add_library(pepper::strcast ALIAS pepper-strcast)
+
+alex_find_package(GoogleTest EXACT 1.8.0 REQUIRED)
+find_package(Threads REQUIRED)
+
+# TODO Implement GoogleTest_AddTest helper
+add_executable(pepper-strcast-test src/strcast.test.cpp)
+add_test(pepper-strcast-test pepper-strcast-test)
+target_include_directories(pepper-strcast-test PRIVATE ${GTEST_INCLUDE_DIRS})
+target_link_libraries(pepper-strcast-test ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(pepper-strcast-test pepper::strcast)
+target_link_libraries(pepper-strcast-test Threads::Threads)

--- a/code/pepper-strcast/README.md
+++ b/code/pepper-strcast/README.md
@@ -1,0 +1,3 @@
+# pepper-strcast
+
+_pepper-strcast_ includes various **lexical casting** helpers.

--- a/code/pepper-strcast/include/pepper/strcast.hpp
+++ b/code/pepper-strcast/include/pepper/strcast.hpp
@@ -1,0 +1,21 @@
+#ifndef __PEPPER_STRCAST_H__
+#define __PEPPER_STRCAST_H__
+
+namespace pepper
+{
+
+/**
+ * @brief Convert a C string value as a value of T type
+ *
+ * safe_strcast(s, v) returns v if s is null.
+ * safe_strcast(s, v) returns a value of T type that corresponds to "s" if "s" is convertible.
+ *
+ * TODO(parjong) Define the behavior when "s" is inconvertible.
+ */
+template<typename T> T safe_strcast(const char *, const T &);
+
+template<> int safe_strcast(const char *s, const int &v);
+
+} // namsepace pepper
+
+#endif // __PEPPER_STRCAST_H__

--- a/code/pepper-strcast/src/strcast.cpp
+++ b/code/pepper-strcast/src/strcast.cpp
@@ -1,0 +1,18 @@
+#include "pepper/strcast.hpp"
+
+#include <string>
+
+namespace pepper
+{
+
+template<> int safe_strcast(const char *s, const int &v)
+{
+  if (s == nullptr)
+  {
+    return v;
+  }
+
+  return std::stoi(s);
+}
+
+} // namespace pepper

--- a/code/pepper-strcast/src/strcast.test.cpp
+++ b/code/pepper-strcast/src/strcast.test.cpp
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+
+#include "pepper/strcast.hpp"
+
+using namespace pepper;
+
+TEST(SafeStrCastTests, cast_int)
+{
+  ASSERT_EQ(safe_strcast<int>(nullptr, 32), 32);
+  ASSERT_EQ(safe_strcast<int>("100", 32), 100);
+}


### PR DESCRIPTION
This commit adds "pepper-strcast" which will provide various lexical
casting helpers.

The initial version supports only "string-to-int" conversion.

Signed-off-by: Jonghyun Park <parjong@gmail.com>