### PR TITLE
Extract core CMake functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,7 @@ set(ALEX_PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR} CACHE INTERNAL "top-level sour
 set(ALEX_PROJECT_BINARY_DIR ${PROJECT_BINARY_DIR} CACHE INTERNAL "top-level binrary directory")
 set(ALEX_OVERLAY_DIR "${ALEX_PROJECT_BINARY_DIR}/overlay" CACHE INTERNAL "overlay directory")
 
-macro(alex_include PREFIX)
-  include("${ALEX_PROJECT_SOURCE_DIR}/infra/cmake/modules/${PREFIX}.cmake")
-endmacro(alex_include)
-
-macro(alex_find_package PREFIX)
-  find_package(${PREFIX} CONFIG NO_DEFAULT_PATH PATHS "${ALEX_PROJECT_SOURCE_DIR}/infra/cmake/packages" ${ARGN})
-endmacro(alex_find_package)
+include(infra/cmake/alex.cmake)
 
 # Set standard C++ 11 (without extension) as the default configuration
 set(CMAKE_CXX_STANDARD 11)

--- a/infra/cmake/alex.cmake
+++ b/infra/cmake/alex.cmake
@@ -1,0 +1,14 @@
+###
+### Alex Core Infrastructure
+###
+if(NOT DEFINED ALEX_PROJECT_SOURCE_DIR)
+  message(FATAL_ERROR "ALEX_PROJECT_SOURCE_DIR is not defined")
+endif(NOT DEFINED ALEX_PROJECT_SOURCE_DIR)
+
+macro(alex_include PREFIX)
+  include("${ALEX_PROJECT_SOURCE_DIR}/infra/cmake/modules/${PREFIX}.cmake")
+endmacro(alex_include)
+
+macro(alex_find_package PREFIX)
+  find_package(${PREFIX} CONFIG NO_DEFAULT_PATH PATHS "${ALEX_PROJECT_SOURCE_DIR}/infra/cmake/packages" ${ARGN})
+endmacro(alex_find_package)


### PR DESCRIPTION
The implementation of alex_include/alex_find_package is currently at the
top-level CMakeLists.txt.

This design makes it impossible to invoke these functions from outside.

This commit introduces a dedicated cmake file to facilitate reuse.

Signed-off-by: Jonghyun Park <parjong@gmail.com>