### PR TITLE
Introduce fipe

### DIFF
--- a/code/fipe/CMakeLists.txt
+++ b/code/fipe/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(fipe INTERFACE)
+target_include_directories(fipe INTERFACE include)
+
+alex_find_package(GoogleTest EXACT 1.8.0 REQUIRED)
+find_package(Threads REQUIRED)
+
+# TODO Implement GoogleTest_AddTest helper
+add_executable(fipe-test fipe.test.cpp)
+add_test(fipe-test fipe-test)
+target_include_directories(fipe-test PRIVATE ${GTEST_INCLUDE_DIRS})
+target_link_libraries(fipe-test ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(fipe-test Threads::Threads)
+target_link_libraries(fipe-test fipe)

--- a/code/fipe/fipe.test.cpp
+++ b/code/fipe/fipe.test.cpp
@@ -1,0 +1,59 @@
+#include "fipe.hpp"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+int dec(int n) { return n - 1; }
+
+} // namespace
+
+TEST(FunctionPipeTests, top_level_function)
+{
+  // fipe::wrap is inevitable.
+  ASSERT_EQ(4 | fipe::wrap(dec), 3);
+}
+
+TEST(FunctionPipeTests, static_method)
+{
+  struct Sample
+  {
+    static int dbl(int n) { return n * 2; }
+  };
+
+  ASSERT_EQ(4 | fipe::wrap(Sample::dbl), 8);
+}
+
+TEST(FunctionPipeTests, normal_method)
+{
+  struct Sample
+  {
+  public:
+    int shift(int n) { return n + shiftamt; }
+
+  private:
+    int shiftamt = 6;
+  };
+
+  using namespace std::placeholders;
+
+  Sample s;
+
+  auto value = 4 | std::bind(&Sample::shift, &s, _1);
+
+  ASSERT_EQ(value, 10);
+}
+
+TEST(FunctionPipeTests, lambda)
+{
+  auto inc = [] (int n) { return n + 1; };
+  ASSERT_EQ(4 | inc, 5);
+}
+
+TEST(FunctionPipeTests, functor)
+{
+  ASSERT_EQ(4 | std::negate<int>(), -4);
+}

--- a/code/fipe/include/fipe.hpp
+++ b/code/fipe/include/fipe.hpp
@@ -1,0 +1,25 @@
+#ifndef __FIPE_H__
+#define __FIPE_H__
+
+#include <functional>
+#include <utility>
+
+namespace fipe
+{
+
+// Wrap a function pointer as a callable std::function
+template <typename Ret, typename Args>
+std::function<Ret (Args)> wrap(Ret (*p)(Args))
+{
+  return p;
+}
+
+} // namespace fipe
+
+template <typename T, typename Callable>
+auto operator|(T &&v, Callable &&f) -> decltype(f(v))
+{
+  return std::forward<Callable>(f)(v);
+}
+
+#endif // __FIPE_H__


### PR DESCRIPTION
This commit introduces fipe, which allows users to chain function calls
in UNIX/Linux pipe syntax.

Signed-off-by: Jonghyun Park <parjong@gmail.com>