### PR TITLE
[pyapp] Update PATH before running Python applications

### DIFF
--- a/infra/command/pyapp
+++ b/infra/command/pyapp
@@ -74,6 +74,7 @@ function alex_pyapp_invoke()
     exit 255
   fi
 
+  export PATH="${ALEX_PYAPP_ENV_DIR}/bin:${PATH}"
   command "${ALEX_PYAPP_ENV_DIR}/bin/python" "${ALEX_PYAPP_DIR}/app.py" "$@"
 }
 


### PR DESCRIPTION
Some Python libraries, such as TensorFlow, assume that 'bin' directory
in Python virtual environments are accessible through PATH.

Signed-off-by: Jonghyun Park <parjong@gmail.com>