### PR TITLE
Introduce 'applet' command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,12 @@ jobs:
           working_directory: infra/applet
           command: |
             ./test-domain python3 domain/python3/samples/r1.0
+      - run:
+          name: Rhe python3 domain tutorial
+          command: |
+            ./alex applet install infra/applet/domain/python3/samples/r1.0
+            ./alex applet run r1.0
+            ./alex applet uninstall r1.0
 
   test_tfgex:
     docker:

--- a/infra/applet/manage
+++ b/infra/applet/manage
@@ -10,10 +10,11 @@
 #
 # This parameter is effective only for 'install' command
 
-readonly APPLET_REGISTRY_DIR=${ALEX_APPLET_REGISTRY:="$SELF_DIR/installed"}
-
 readonly SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly MANIFEST_FILENAME="alex.applet"
+
+# WARNING! Declare APPLET_REGISTRY_DIR after SELF_DIR
+readonly APPLET_REGISTRY_DIR=${ALEX_APPLET_REGISTRY:="$SELF_DIR/installed"}
 
 # read_conf <path/to/file> <VARIABLE NAME>
 # TODO Extract this helper as orb

--- a/infra/command/applet
+++ b/infra/command/applet
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# From BASH Reference Manual
+#
+# Section 4.2 Bash Builtin Commands - source
+#
+# A synonym for . (see Bourne Shell Builtins).
+#
+# Section 4.1 Bourne Shell Builtins - . (a period)
+# 
+# Read and execute commands from the filename argument in the current shell context.
+source "$ALEX_PROJECT_PATH/infra/applet/manage" "$@"


### PR DESCRIPTION
This commit introduces 'applet' command, which makes it easy to access
applet framework from the top-level 'alex' command.

This commit fixes a bug in the applet manager (along with a CI test) to
enable this feature.

Signed-off-by: Jonghyun Park <parjong@gmail.com>