### PR TITLE
Fix 'python3' domain

### DIFF
--- a/infra/applet/domain/python3/manage
+++ b/infra/applet/domain/python3/manage
@@ -80,6 +80,8 @@ function applet_init()
 # 'run' COMMAND
 function applet_run()
 {
+  ensure_variable "APPLET_NAME"
+
   ensure_variable "APPLET_CODE_DIR"
   ensure_variable "APPLET_DATA_DIR"
 
@@ -134,7 +136,7 @@ case $COMMAND in
     applet_init
     ;;
   run)
-    applet_run
+    applet_run "$@"
     ;;
   update)
     applet_update

--- a/infra/applet/manage
+++ b/infra/applet/manage
@@ -194,7 +194,7 @@ function applet_install()
 
 function applet_run()
 {
-  local APPLET_NAME="$1"; shift
+  export APPLET_NAME="$1"; shift
   local APPLET_STAMP_PATH=$(applet_stamp_path_of $APPLET_NAME)
 
   if [[ ! -f $APPLET_STAMP_PATH ]]; then


### PR DESCRIPTION
There are two bugs in 'python3' domain.

First, the domain manager does not pass command-line arguments.
Therefore, it is impossible to use command-line arguments.

Second, the applet manger does not pass APPLET_NAME on run, which leads
to invalid error message.

This commit fixes these two bugs.

Signed-off-by: Jonghyun Park <parjong@gmail.com>