### PR TITLE
[mas] Add compute.WGT.size.mas

### DIFF
--- a/spo/mas/code/mas/core.py
+++ b/spo/mas/code/mas/core.py
@@ -163,6 +163,9 @@ class MASTensorEndpoint:
   def byte_size(self):
     return self.elem_count * (self.elem.avgbit / 8)
 
+  def is_model_const(self):
+    return self.id.src == ModelConst
+
   def is_layer_output(self):
     return self.id.src == LayerOutput
 # class MASTensorEndpoint: END

--- a/spo/mas/example/basic/compute.WGT.size.mas
+++ b/spo/mas/example/basic/compute.WGT.size.mas
@@ -1,0 +1,18 @@
+mas = get_mas_session()
+
+# Collect effective model constants (a.k.a model weight)
+used_mcon_set = set()
+
+for layer in mas.model.layers:
+  for layer_input_value in layer.inputs:
+    if not layer_input_value.is_model_const():
+      continue
+    used_mcon_set.add(layer_input_value.id)
+
+# Accumulate the size of effective model constants
+wgt_size = 0.0
+
+for wgt_value_id in used_mcon_set:
+  wgt_size += mas.model.value(wgt_value_id).byte_size
+
+mas.set_attr('basic.WGT.size', wgt_size)


### PR DESCRIPTION
This commit extends mas core with is_model_const helper, and adds
'compute.WGT.size.mas' as a working example.

Signed-off-by: Jonghyun Park <parjong@gmail.com>